### PR TITLE
Feature/data display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@testing-library/jest-dom": "^5.12.0",
         "@testing-library/react": "^11.2.6",
         "@testing-library/user-event": "^12.8.3",
+        "dayjs": "^1.10.4",
         "node-sass": "^6.0.0",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -6333,6 +6334,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "node_modules/debug": {
       "version": "4.3.1",
@@ -27246,6 +27252,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw=="
     },
     "debug": {
       "version": "4.3.1",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.12.0",
     "@testing-library/react": "^11.2.6",
     "@testing-library/user-event": "^12.8.3",
+    "dayjs": "^1.10.4",
     "node-sass": "^6.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/MovieInfo.js
+++ b/src/components/MovieInfo.js
@@ -1,6 +1,9 @@
 import React, { Component } from 'react';
 import apiCalls from '../apiCalls';
-var dayjs = require('dayjs')
+var dayjs = require('dayjs');
+// var duration = require('dayjs/plugin/duration');
+// dayjs.extend(duration);
+
 
 class MovieInfo extends Component {
     constructor() {
@@ -22,6 +25,11 @@ class MovieInfo extends Component {
         currency: 'USD',
       })
       return formatter.format(amount);
+    }
+
+    displayGenres(genres) {
+      const list = genres.join(', ')
+      return list
     }
 
     render() {
@@ -48,9 +56,9 @@ class MovieInfo extends Component {
                 <h1 className='title'>{this.state.movie.title}</h1>
                 <p className='release-date'>Release Date: {dayjs(this.state.movie.release_date).format('MMMM D, YYYY')}</p>
                 <p className='overview'>{this.state.movie.overview}</p>
-                <p className='runtime'>{dayjs(this.state.movie.runtime).format('HH-MM')} minutes</p>
+                <p className='runtime'>{this.state.movie.runtime} minutes</p>
                 <p className='avg-rating'>Average Rating: {this.state.movie.average_rating}</p>
-                <p className='genres'>Genre: {this.state.movie.genres}</p>
+                <p className='genres'>Genre: {this.displayGenres(this.state.movie.genres)}</p>
                 <p className='budget'>Budget: {this.convertDollarAmount(this.state.movie.budget)}</p>
                 <p className='revenue'>Revenue: {this.convertDollarAmount(this.state.movie.revenue)}</p>
               </div>

--- a/src/components/MovieInfo.js
+++ b/src/components/MovieInfo.js
@@ -16,6 +16,14 @@ class MovieInfo extends Component {
       .catch(error => this.setState({ error: error }))
     }
 
+    convertDollarAmount(amount) {
+      let formatter = new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD',
+      })
+      return formatter.format(amount);
+    }
+
     render() {
     if(!this.state.movie) {
       return (<p>Your flick is loading...</p>)
@@ -40,11 +48,11 @@ class MovieInfo extends Component {
                 <h1 className='title'>{this.state.movie.title}</h1>
                 <p className='release-date'>Release Date: {dayjs(this.state.movie.release_date).format('MMMM D, YYYY')}</p>
                 <p className='overview'>{this.state.movie.overview}</p>
-                <p className='runtime'>{this.state.movie.runtime} minutes</p>
+                <p className='runtime'>{dayjs(this.state.movie.runtime).format('HH-MM')} minutes</p>
                 <p className='avg-rating'>Average Rating: {this.state.movie.average_rating}</p>
                 <p className='genres'>Genre: {this.state.movie.genres}</p>
-                <p className='budget'>Budget: {this.state.movie.budget}</p>
-                <p className='revenue'>Revenue: {this.state.movie.revenue}</p>
+                <p className='budget'>Budget: {this.convertDollarAmount(this.state.movie.budget)}</p>
+                <p className='revenue'>Revenue: {this.convertDollarAmount(this.state.movie.revenue)}</p>
               </div>
               <button onClick={this.props.changeDisplay}>Return Home</button>
             </div>

--- a/src/components/MovieInfo.js
+++ b/src/components/MovieInfo.js
@@ -24,7 +24,13 @@ class MovieInfo extends Component {
         style: 'currency',
         currency: 'USD',
       })
-      return formatter.format(amount);
+      const dollarAmt = formatter.format(amount);
+
+      if(dollarAmt === '$0.00') {
+        return 'This information is unavailable'
+        } else {
+          return dollarAmt
+        }
     }
 
     displayGenres(genres) {
@@ -40,7 +46,7 @@ class MovieInfo extends Component {
     if(this.state.error) {
       return (<p>{this.state.error}</p>)
     }
-
+     console.log(this.state.movie.revenue)
     return (
       <section className='movie-info-container' style={{ backgroundImage: `url(${this.state.movie.backdrop_path})`}}>
         <div className='movie-info'>
@@ -57,7 +63,7 @@ class MovieInfo extends Component {
                 <p className='release-date'>Release Date: {dayjs(this.state.movie.release_date).format('MMMM D, YYYY')}</p>
                 <p className='overview'>{this.state.movie.overview}</p>
                 <p className='runtime'>{this.state.movie.runtime} minutes</p>
-                <p className='avg-rating'>Average Rating: {this.state.movie.average_rating}</p>
+                <p className='avg-rating'>Average Rating: {Math.round(this.state.movie.average_rating)}</p>
                 <p className='genres'>Genre: {this.displayGenres(this.state.movie.genres)}</p>
                 <p className='budget'>Budget: {this.convertDollarAmount(this.state.movie.budget)}</p>
                 <p className='revenue'>Revenue: {this.convertDollarAmount(this.state.movie.revenue)}</p>

--- a/src/components/MovieInfo.js
+++ b/src/components/MovieInfo.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import apiCalls from '../apiCalls';
+var dayjs = require('dayjs')
 
 class MovieInfo extends Component {
     constructor() {
@@ -37,7 +38,7 @@ class MovieInfo extends Component {
             <div className='movie-right-wrapper'>
               <div className='movie-info-box'>
                 <h1 className='title'>{this.state.movie.title}</h1>
-                <p className='release-date'>Release Date: {this.state.movie.release_date}</p>
+                <p className='release-date'>Release Date: {dayjs(this.state.movie.release_date).format('MMMM D, YYYY')}</p>
                 <p className='overview'>{this.state.movie.overview}</p>
                 <p className='runtime'>{this.state.movie.runtime} minutes</p>
                 <p className='avg-rating'>Average Rating: {this.state.movie.average_rating}</p>


### PR DESCRIPTION
## Is this a fix or a feature?
- feature

## What is the change?
- In `MovieInfo.js` the state display format has been updated
- DayJS used to format date
- budget & revenue updated to reflect currency or "not available" if the revenue is $0.00
- Rating rounded to nearest whole number


## What does it fix?


## Where should the reviewer start?
- All changes were made in `MovieInfo.js`

## How should this be tested?
- Run `npm install` to install Dayjs package
- view code in browser

## What are the next steps?
