### PR TITLE
Fixed Router refresh issue

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,8 +17,8 @@ class App extends Component {
 
   componentDidMount = () => {
     apiCalls.fetchAllMovies()
-      .then(data => this.setState({movies: data.movies}))
-      .catch(error => this.setState( {error: error}))
+      .then(data => this.setState({ movies: data.movies }))
+      .catch(error => this.setState( { error: error }))
   }
 
   handleClick = (e) => {
@@ -27,7 +27,7 @@ class App extends Component {
   }
 
   changeDisplay = () => {
-    this.setState( {cardID: 0 });
+    this.setState( { cardID: 0 });
   }
 
   render() {
@@ -39,8 +39,8 @@ class App extends Component {
     return (
       <div className='main-page'>
         <Header />
-        <Route exact path='/:id' render={() =>
-          <MovieInfo id={this.state.cardID} changeDisplay={this.changeDisplay}/>
+        <Route exact path='/:id' render={({ match }) =>
+          <MovieInfo id={match.params.id} changeDisplay={this.changeDisplay}/>
         }/>
         <Route exact path='/' render={() =>
           <MovieLibrary movies={this.state.movies} handleClick={this.handleClick}/>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-function Card({id, test, posterPath, handleClick}) {
+function Card({ id, test, posterPath, handleClick }) {
 
   return (
     <Link to={`/${id}`} className='link-container'>

--- a/src/components/MovieInfo.js
+++ b/src/components/MovieInfo.js
@@ -7,47 +7,47 @@ var dayjs = require('dayjs');
 
 
 class MovieInfo extends Component {
-    constructor() {
-      super()
-      this.state = {
-        movie: null
-      }
+  constructor(props) {
+    super(props)
+    this.state = {
+      movie: null
     }
+  }
 
-    componentDidMount = () => {
-      apiCalls.fetchAMovie(this.props.id)
+  componentDidMount = () => {
+    apiCalls.fetchAMovie(this.props.id)
       .then(data => this.setState({ movie: data.movie }))
       .catch(error => this.setState({ error: error }))
-    }
+  }
 
-    convertDollarAmount(amount) {
-      let formatter = new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD',
-      })
-      const dollarAmt = formatter.format(amount);
+  convertDollarAmount(amount) {
+    let formatter = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    })
+    const dollarAmt = formatter.format(amount);
 
-      if(dollarAmt === '$0.00') {
-        return 'This information is unavailable'
-        } else {
-          return dollarAmt
-        }
-    }
+    if (dollarAmt === '$0.00') {
+      return 'This information is unavailable'
+      } else {
+        return dollarAmt;
+      }
+  }
 
-    displayGenres(genres) {
-      const list = genres.join(', ')
-      return list
-    }
+  displayGenres(genres) {
+    const list = genres.join(', ')
+    return list;
+  }
 
-    render() {
-    if(!this.state.movie) {
+  render() {
+    if (!this.state.movie) {
       return (<p>Your flick is loading...</p>)
     }
 
-    if(this.state.error) {
+    if (this.state.error) {
       return (<p>{this.state.error}</p>)
     }
-  
+
     return (
       <section className='movie-info-container' style={{ backgroundImage: `url(${this.state.movie.backdrop_path})`}}>
         <div className='movie-info'>

--- a/src/components/MovieLibrary.js
+++ b/src/components/MovieLibrary.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Card from './Card.js';
 
-function MovieLibrary({movies, handleClick}) {
+function MovieLibrary({ movies, handleClick }) {
     const newCards = movies.map(film => {
       return (
         <Card


### PR DESCRIPTION
## Is this a fix or a feature?
Fix

## What does it fix?
- Replaced `this.state.cardID` with `match.params.id` so that `/:id` value (URL prop of <Route> object) is passed into MovieInfo.
- MovieInfo display now properly fetches data on page refresh, and this also allows us to navigate with back and forward buttons!

## Where should the reviewer start?
- Just the render() method in `App.js`

## How should this be tested?
- Run in browser and Cypress

## What are the next steps?
- I think that already takes care of Iteration 4!  Back to testing.