### PR TITLE
Built commands.js and refactored all testing

### DIFF
--- a/cypress/integration/main-page-test.js
+++ b/cypress/integration/main-page-test.js
@@ -1,64 +1,50 @@
-describe('Main Display', () => {
+describe('Main Page', () => {
 
-  before(() => {
-    cy.fixture('../fixtures/movies-data.json')
-      .then((movies) => {
-        cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
-          body: movies,
-          statusCode: 200,
-        });
-      });
-    cy.visit('http://localhost:3000')
+  beforeEach(() => {
+    // see: cypress/support/commands.js
+    cy.stubAllMoviesData()
   });
 
-  it('Should display a loading page while fetching movie data', () => {
-    cy.reload()
-      .get('.message').should('contain', 'Page Loading 🍿')
-      .should('be.visible')
+  describe('Main Loading', () => {
+
+    it('Should display a loading message while fetching movie data', () => {
+      cy.interceptAllMoviesData().reload()
+      cy.get('.message')
+        .should('contain', 'Page Loading 🍿')
+        .should('be.visible')
+    });
+
+    it('Should remove loading message once movies have loaded', () => {
+      cy.get('.message').should('not.exist')
+    });
+
   });
 
-  it('Should remove loading message once movies have loaded', () => {
-    cy.get('.message').should('not.exist')
+  describe('Main Render', () => {
+
+    it('Should render the main page', () => {
+      cy.get('h1').contains('Rancid Tomatillos')
+        .get('#694919')
+        .get('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg')
+    });
+
+    it('Should display all movies in the fetched dataset', () => {
+      cy.get('.library')
+        .find('.movie-card').should('have.length', 1)
+    });
+
+    it('Should display correct path on page load', () => {
+      cy.url().should('eq', 'http://localhost:3000/')
+    });
+
   });
 
-  it('Should render the main page', () => {
-    cy.get('h1').contains('Rancid Tomatillos')
-      .get('#694919')
-      .get('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg')
-  });
+  describe('Main Click', () => {
 
-  it('Should display all movies in the fetched dataset', () => {
-    cy.get('.library')
-      .find('.movie-card').should('have.length', 1)
-  });
-
-  it('Should display correct path on page load', () => {
-    cy.url().should('eq', 'http://localhost:3000/')
-  });
-});
-
-
-describe('Main Click', () => {
-
-  it('Should be able to click a movie poster to go display that movie\'s info', () => {
-    cy.fixture('../fixtures/movies-data.json')
-      .then((movies) => {
-        cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
-          body: movies,
-          statusCode: 200,
-        });
-        cy.visit('http://localhost:3000')
-          .get('.message').should('contain', 'Page Loading 🍿')
-      });
-
-    cy.fixture('../fixtures/single-movie-data.json')
-      .then((movie) => {
-        cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies/694919', {
-          body: movie,
-          statusCode: 200,
-        });
-        cy.get('.movie-card').click()
-          .url().should('eq', 'http://localhost:3000/694919')
+    it('Should be able to click a movie poster to go display that movie\'s info', () => {
+      cy.interceptSingleMovieData()
+        .get('.movie-card').click()
+        .url().should('eq', 'http://localhost:3000/694919')
     });
   });
 

--- a/cypress/integration/movie-info-test.js
+++ b/cypress/integration/movie-info-test.js
@@ -1,39 +1,28 @@
-describe('Movie Info Loading', () => {
+describe('Movie Info Page', () => {
 
-  it('Should display a loading page while fetching movie data', () => {
+  beforeEach(() => {
+    // see: cypress/support/commands.js
+    cy.stubSingleMovieData()
+  });
 
-    cy.fixture('../fixtures/single-movie-data.json')
-      .then((movie) => {
-        cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies/694919', {
-          body: movie,
-          delay: 100,
-          statusCode: 200,
-        });
-        cy.visit('http://localhost:3000/694919')
-      });
+  describe('Movie Info Loading', () => {
 
-      cy.wait(150).get('.message').should('contain', 'Page Loading 🍿')
+    it('Should display a loading page while fetching movie data', () => {
+      cy.get('.message')
+        .should('contain', 'Page Loading 🍿')
         .should('be.visible')
-      cy.wait(150).reload()
+    });
+
+    it('Should remove loading message once movies have loaded', () => {
+      cy.get('.message').should('not.exist')
+    });
+
   });
 
-});
+  describe('Movie Info Display', () => {
 
-describe('Movie Info Display', () => {
-
-  before(() => {
-    cy.fixture('../fixtures/single-movie-data.json')
-      .then((movie) => {
-        cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies/694919', {
-          body: movie,
-          statusCode: 200,
-        });
-      });
-    cy.visit('http://localhost:3000/694919')
-  });
-
-  it('Should render the movie info display', () => {
-    cy.get('.title').contains('Money Plane')
+    it('Should render all data for the movie info display', () => {
+      cy.get('.title').contains('Money Plane')
       .get('img').should('have.attr', 'src', 'https://image.tmdb.org/t/p/original//6CoRTJTmijhBLJTUNoVSUNxZMEI.jpg')
       .get('section').should('have.css', 'background-image', 'url("https://image.tmdb.org/t/p/original//pq0JSpwyT2URytdFG0euztQPAyR.jpg")')
       .get('.release-date').contains('September 29, 2020')
@@ -44,35 +33,23 @@ describe('Movie Info Display', () => {
       .get('.runtime').contains(82)
       .get('.tagline').eq('')
       .get('.avg-rating').contains(6)
-  });
-
-});
-
-describe('Home Click', () => {
-
-  it('Should go back to main page view when the Return Home button is clicked', () => {
-
-    cy.fixture('../fixtures/single-movie-data.json')
-      .then((movie) => {
-      cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies/694919', {
-        body: movie,
-        delay: 300,
-        statusCode: 200,
-      });
-      cy.visit('http://localhost:3000/694919')
     });
 
-    cy.fixture('../fixtures/movies-data.json')
-      .then((movies) => {
-        cy.intercept('https://rancid-tomatillos.herokuapp.com/api/v2/movies', {
-          body: movies,
-          delay: 300,
-          statusCode: 200,
-        });
-        cy.wait(300).get('button').click().reload()
-          .url().should('eq', 'http://localhost:3000/')
-          .get('.library').find('.movie-card').should('have.length', 1)
-      });
+  });
+
+  describe('Return Home Click', () => {
+
+    before(() => {
+      cy.interceptAllMoviesData()
+    });
+
+    it('Should go back to main page view when the Return Home button is clicked', () => {
+
+      cy.get('button').click()
+        .url().should('eq', 'http://localhost:3000/')
+        .get('.library').find('.movie-card').should('have.length', 1)
+    });
+
   });
 
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,25 +1,22 @@
-// ***********************************************
-// This example commands.js shows you how to
-// create various custom commands and overwrite
-// existing commands.
-//
-// For more comprehensive examples of custom
-// commands please read more here:
-// https://on.cypress.io/custom-commands
-// ***********************************************
-//
-//
-// -- This is a parent command --
-// Cypress.Commands.add('login', (email, password) => { ... })
-//
-//
-// -- This is a child command --
-// Cypress.Commands.add('drag', { prevSubject: 'element'}, (subject, options) => { ... })
-//
-//
-// -- This is a dual command --
-// Cypress.Commands.add('dismiss', { prevSubject: 'optional'}, (subject, options) => { ... })
-//
-//
-// -- This will overwrite an existing command --
-// Cypress.Commands.overwrite('visit', (originalFn, url, options) => { ... })
+import allMoviesData from '../fixtures/movies-data.json';
+import singleMovieData from '../fixtures/single-movie-data.json';
+
+const baseURL = 'https://rancid-tomatillos.herokuapp.com/api/v2/movies'
+
+Cypress.Commands.add('stubAllMoviesData', () => {
+  cy.intercept(baseURL, allMoviesData)
+    .visit('http://localhost:3000/')
+})
+
+Cypress.Commands.add('stubSingleMovieData', () => {
+  cy.intercept(`${baseURL}/694919`, singleMovieData)
+    .visit('http://localhost:3000/694919')
+});
+
+Cypress.Commands.add('interceptAllMoviesData', () => {
+  cy.intercept(baseURL, allMoviesData)
+})
+
+Cypress.Commands.add('interceptSingleMovieData', () => {
+  cy.intercept(`${baseURL}/694919`, singleMovieData)
+});


### PR DESCRIPTION
## Is this a fix or a feature?
Refactor

## What is the change?
Total refactor of our Cypress testing:
- Built out `commands.js` file with reusable functions to intercept and stub both 'allMovies' and 'singleMovie' fetch requests
- Removed all `.wait()` and several `.reload()` methods and substituted async functionality with effective use of command functions, assisted by replacement of 'before' functions with 'beforeEach', when possible.
- Much cleaner, DRYer, and should be easy to add additional tests when we think of them!

## Where should the reviewer start?
- Take a look at the new `commands.js` functions (see: `cypress/support/commands.js`) as well as all of our test files.

## How should this be tested?
- Run Cypress tests

## What are the next steps?
- Page deployment and any other Iteration 5 tasks